### PR TITLE
Added a bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: You found a bug? Great! If you are a new bug reporter, you might want to use
+  our template. Feel free to change its structure as you wish.
+
+---
+
+**Bug description** (required)
+A clear and concise description of what the bug is.
+
+**How to reproduce the bug** (required)
+Is the bug reproducible (it can happen multiple times, and ideally in different computers)? If so, how did you encountered the bug? What were the conditions, if any?
+
+**Expected behavior** (required)
+A clear and concise description of what you expected to happen.
+
+**Computer information** (required)
+Operating system: (Windows, Mac OS X, Linux-based)
+Steam version: (yes/no)
+Endless Sky version: (stable, unstable, git)
+Plugins used: (If applicable. If it is self-made, please upload your plugin in "Additional Information". Also, please test if you can reproduce the bug in vanilla, meaning no plugins/mods. If the bug cannot be reproduced in vanilla, most likely this thread will be closed.)
+
+**Additional information**
+Add any other useful information about the problem here, like your save file, screenshots, debug logs, and your CPU and GPU.


### PR DESCRIPTION
This template is intended for new bug reporters. No more "how can you reproduce this bug", "are you using mods", "are you using the Steam version", "what version of Endless Sky are you using", "what is your operating system", etc., etc.